### PR TITLE
Offer to choose a certain grammar

### DIFF
--- a/black.py
+++ b/black.py
@@ -164,15 +164,14 @@ def read_pyproject_toml(
     return value
 
 
-GRAMMARS = [
-    ["py3", pygram.python_grammar_no_print_statement_no_exec_statement],
-    ["py2", pygram.python_grammar_no_print_statement],
-    ["py2_print_stmt", pygram.python_grammar],
+GRAMMARS: List[Tuple[str, Any]] = [
+    ("py3", pygram.python_grammar_no_print_statement_no_exec_statement),
+    ("py2", pygram.python_grammar_no_print_statement),
+    ("py2_print_stmt", pygram.python_grammar),
 ]
-
-grammar_choices = ["all"]  # the default: we try any, in the order given
+grammar_choices: List[str] = ["all"]  # the default: we try any, in the order given
 grammar_choices.extend([g[0] for g in GRAMMARS])  # click option
-grammar_chosen = []
+grammar_chosen: List[str] = []
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))


### PR DESCRIPTION
Hi, this addresses #423 and #522, based on the suggestion I made in #423. 

If you accept, the user would have the choice to force Black to use only one grammar when trying to build the AST - so that syntax errors do match the *intended* source code grammar and are not misleading.

I had to do this via a cli switch only and set process wide - passing it through your config machinery proved hard, could not manage to make it w/o tons of tests failing. But I think process wide is ok: When formatting many files through the subproc scheduler, then syntax errors should not be the problem -this is more for live coding and formatting in the editor. In the vim plugin I just set

```
black.grammar_chosen.append('py3') after its import, don't need a conditional.
```

Thanks for Black & hope you == ok with it

![image](https://user-images.githubusercontent.com/9989548/45928293-8b8f3d80-bf41-11e8-9798-83a3a07aba0b.png)
