### PR TITLE
Use g:pymode_python-defined interpreter if defined and exists, otherwise use existing defaults

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -42,8 +42,11 @@ import sys
 import vim
 
 def _get_python_binary(exec_prefix):
-  default = vim.eval("g:pymode_python").strip()
-  if os.path.exists(default):
+  try:
+      default = vim.eval("g:pymode_python").strip()
+  except:
+      default = ""
+  if default and os.path.exists(default):
     return default
   if sys.platform[:3] == "win":
     return exec_prefix / 'python.exe'

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -43,9 +43,9 @@ import vim
 
 def _get_python_binary(exec_prefix):
   try:
-      default = vim.eval("g:pymode_python").strip()
-  except:
-      default = ""
+    default = vim.eval("g:pymode_python").strip()
+  except vim.error:
+    default = ""
   if default and os.path.exists(default):
     return default
   if sys.platform[:3] == "win":

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -37,10 +37,14 @@ if !exists("g:black_skip_string_normalization")
 endif
 
 python3 << endpython3
+import os
 import sys
 import vim
 
 def _get_python_binary(exec_prefix):
+  default = vim.eval("g:pymode_python").strip()
+  if os.path.exists(default):
+    return default
   if sys.platform[:3] == "win":
     return exec_prefix / 'python.exe'
   return exec_prefix / 'bin' / 'python3'


### PR DESCRIPTION
This is helpful when using custom-compiled interpreters, or alternative Python interpreters in non-standard locations