### PR TITLE
Default to current directory if no paths are specified

### DIFF
--- a/black.py
+++ b/black.py
@@ -55,6 +55,7 @@ DEFAULT_EXCLUDES = (
     r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)/"
 )
 DEFAULT_INCLUDES = r"\.pyi?$"
+DEFAULT_SRC = (".",)
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))
 
 
@@ -200,7 +201,7 @@ def read_pyproject_toml(
     """
     assert not isinstance(value, (int, bool)), "Invalid parameter type passed"
     if not value:
-        root = find_project_root(ctx.params.get("src", ()))
+        root = find_project_root(ctx.params.get("src", DEFAULT_SRC))
         path = root / "pyproject.toml"
         if path.is_file():
             value = str(path)
@@ -385,6 +386,8 @@ def main(
     report = Report(check=check, quiet=quiet, verbose=verbose)
     root = find_project_root(src)
     sources: Set[Path] = set()
+    if not src:
+        src = DEFAULT_SRC
     for s in src:
         p = Path(s)
         if p.is_dir():


### PR DESCRIPTION
I usually run Black on the current directory:

```
black .
```

Similarly for Flake8, the other Python CLI tool I often run:

```
flake8 .
```

And Flake8 [defaults to search in the current directory](https://gitlab.com/pycqa/flake8/blob/88caf5ac484f5c09aedc02167c59c66ff0af0068/src/flake8/checker.py#L203). This is the same:

```
flake8
```

I'd like to ask for Black to do the same:

```
black
```

Benefits:
* Less typing
* Consistency
