### PR TITLE
add `black -c "code"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ black {source_file_or_directory}
 black [OPTIONS] [SRC]...
 
 Options:
+  -c, --command TEXT              Format the code passed in as a string.
   -l, --line-length INTEGER       How many characters per line to allow.
                                   [default: 88]
   -t, --target-version [py27|py33|py34|py35|py36|py37|py38]
@@ -950,6 +951,10 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
 
 
 ## Change Log
+
+### 19.3b1
+
+* add `black -c` as a way to format code passed from the command line
 
 ### 19.3b0
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ black {source_file_or_directory}
 black [OPTIONS] [SRC]...
 
 Options:
-  -c, --command TEXT              Format the code passed in as a string.
+  -c, --code TEXT                 Format the code passed in as a string.
   -l, --line-length INTEGER       How many characters per line to allow.
                                   [default: 88]
   -t, --target-version [py27|py33|py34|py35|py36|py37|py38]

--- a/black.py
+++ b/black.py
@@ -227,9 +227,7 @@ def read_pyproject_toml(
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.option(
-    "-c", "--command", type=str, help="Format the code passed in as a string."
-)
+@click.option("-c", "--code", type=str, help="Format the code passed in as a string.")
 @click.option(
     "-l",
     "--line-length",
@@ -356,7 +354,7 @@ def read_pyproject_toml(
 @click.pass_context
 def main(
     ctx: click.Context,
-    command: Optional[str],
+    code: Optional[str],
     line_length: int,
     target_version: List[TargetVersion],
     check: bool,
@@ -397,8 +395,8 @@ def main(
     )
     if config and verbose:
         out(f"Using configuration from {config}.", bold=False, fg="blue")
-    if command is not None:
-        print(format_str(command, mode=mode))
+    if code is not None:
+        print(format_str(code, mode=mode))
         ctx.exit(0)
     try:
         include_regex = re_compile_maybe_verbose(include)

--- a/black.py
+++ b/black.py
@@ -228,6 +228,9 @@ def read_pyproject_toml(
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option(
+    "-c", "--command", type=str, help="Format the code passed in as a string."
+)
+@click.option(
     "-l",
     "--line-length",
     type=int,
@@ -353,6 +356,7 @@ def read_pyproject_toml(
 @click.pass_context
 def main(
     ctx: click.Context,
+    command: Optional[str],
     line_length: int,
     target_version: List[TargetVersion],
     check: bool,
@@ -393,6 +397,9 @@ def main(
     )
     if config and verbose:
         out(f"Using configuration from {config}.", bold=False, fg="blue")
+    if command is not None:
+        print(format_str(command, mode=mode))
+        ctx.exit(0)
     try:
         include_regex = re_compile_maybe_verbose(include)
     except re.error:


### PR DESCRIPTION
Useful as a way to quickly try out what Black does on a chunk of code. A `-c` option with similar behavior is also in mypy and python itself.