### PR TITLE
minor: remove wrong comment in .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,3 @@
-# This is an example .flake8 config, used when developing *Black* itself.
-# Keep in sync with setup.cfg which is used for source packages.
-
 [flake8]
 ignore = E203, E266, E501, W503
 max-line-length = 80


### PR DESCRIPTION
This is there since the initial commit, which did not have a setup.cfg.