### PR TITLE
Welcome to your new home! ambv/black -> python/black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ deploy:
   skip_cleanup: true
   on:
     condition: $TRAVIS_PYTHON_VERSION == '3.6'
-    repo: ambv/black
+    repo: python/black
     tags: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ In terms of inspiration, *Black* is about as configurable as *gofmt*.
 This is deliberate.
 
 Bug reports and fixes are always welcome!  Please follow the [issue
-template on GitHub](https://github.com/ambv/black/issues/new) for best 
+template on GitHub](https://github.com/python/black/issues/new) for best 
 results.
 
 Before you suggest a new feature or configuration knob, ask yourself why

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-![Black Logo](https://raw.githubusercontent.com/ambv/black/master/docs/_static/logo2-readme.png)
+![Black Logo](https://raw.githubusercontent.com/python/black/master/docs/_static/logo2-readme.png)
 <h2 align="center">The Uncompromising Code Formatter</h2>
 
 <p align="center">
-<a href="https://travis-ci.org/ambv/black"><img alt="Build Status" src="https://travis-ci.org/ambv/black.svg?branch=master"></a>
+<a href="https://travis-ci.org/python/black"><img alt="Build Status" src="https://travis-ci.org/python/black.svg?branch=master"></a>
 <a href="https://black.readthedocs.io/en/stable/?badge=stable"><img alt="Documentation Status" src="https://readthedocs.org/projects/black/badge/?version=stable"></a>
-<a href="https://coveralls.io/github/ambv/black?branch=master"><img alt="Coverage Status" src="https://coveralls.io/repos/github/ambv/black/badge.svg?branch=master"></a>
-<a href="https://github.com/ambv/black/blob/master/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
+<a href="https://coveralls.io/github/python/black?branch=master"><img alt="Coverage Status" src="https://coveralls.io/repos/github/python/black/badge.svg?branch=master"></a>
+<a href="https://github.com/python/black/blob/master/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
 <a href="https://pypi.org/project/black/"><img alt="PyPI" src="https://black.readthedocs.io/en/stable/_static/pypi.svg"></a>
 <a href="https://pepy.tech/project/black"><img alt="Downloads" src="https://pepy.tech/badge/black"></a>
-<a href="https://github.com/ambv/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+<a href="https://github.com/python/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 
 > “Any color you like.”
@@ -370,7 +370,7 @@ The main reason to standardize on a single form of quotes is aesthetics.
 Having one kind of quotes everywhere reduces reader distraction.
 It will also enable a future version of *Black* to merge consecutive
 string literals that ended up on the same line (see
-[#26](https://github.com/ambv/black/issues/26) for details).
+[#26](https://github.com/python/black/issues/26) for details).
 
 Why settle on double quotes?  They anticipate apostrophes in English
 text.  They match the docstring standard described in [PEP 257](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring).
@@ -694,16 +694,16 @@ Configuration:
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```
-Plug 'ambv/black'
+Plug 'python/black'
 ```
 
 or with [Vundle](https://github.com/VundleVim/Vundle.vim):
 
 ```
-Plugin 'ambv/black'
+Plugin 'python/black'
 ```
 
-or you can copy the plugin from [plugin/black.vim](https://github.com/ambv/black/tree/master/plugin/black.vim).
+or you can copy the plugin from [plugin/black.vim](https://github.com/python/black/tree/master/plugin/black.vim).
 Let me know if this requires any changes to work with Vim 8's builtin
 `packadd`, or Pathogen, and so on.
 
@@ -856,7 +856,7 @@ installed](https://pre-commit.com/#install), add this to the
 `.pre-commit-config.yaml` in your repository:
 ```yaml
 repos:
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/python/black
     rev: stable
     hooks:
     - id: black
@@ -916,16 +916,16 @@ and [`pipenv`](https://docs.pipenv.org/):
 Use the badge in your project's README.md:
 
 ```markdown
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 ```
 
 Using the badge in README.rst:
 ```
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/ambv/black
+    :target: https://github.com/python/black
 ```
 
-Looks like this: [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+Looks like this: [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 
 ## License

--- a/black.py
+++ b/black.py
@@ -3386,7 +3386,7 @@ def assert_equivalent(src: str, dst: str) -> None:
         log = dump_to_file("".join(traceback.format_tb(exc.__traceback__)), dst)
         raise AssertionError(
             f"INTERNAL ERROR: Black produced invalid code: {exc}. "
-            f"Please report a bug on https://github.com/ambv/black/issues.  "
+            f"Please report a bug on https://github.com/python/black/issues.  "
             f"This invalid output might be helpful: {log}"
         ) from None
 
@@ -3397,7 +3397,7 @@ def assert_equivalent(src: str, dst: str) -> None:
         raise AssertionError(
             f"INTERNAL ERROR: Black produced code that is not equivalent to "
             f"the source.  "
-            f"Please report a bug on https://github.com/ambv/black/issues.  "
+            f"Please report a bug on https://github.com/python/black/issues.  "
             f"This diff might be helpful: {log}"
         ) from None
 
@@ -3413,7 +3413,7 @@ def assert_stable(src: str, dst: str, mode: FileMode) -> None:
         raise AssertionError(
             f"INTERNAL ERROR: Black produced different code on the second pass "
             f"of the formatter.  "
-            f"Please report a bug on https://github.com/ambv/black/issues.  "
+            f"Please report a bug on https://github.com/python/black/issues.  "
             f"This diff might be helpful: {log}"
         ) from None
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,7 +161,7 @@ html_theme_options = {
     "show_related": False,
     "description": "“Any color you like.”",
     "github_button": True,
-    "github_user": "ambv",
+    "github_user": "python",
     "github_repo": "black",
     "github_type": "star",
     "show_powered_by": True,

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,4 +6,4 @@ dependencies:
 - Sphinx==1.7.2
 - pip:
   - recommonmark==0.4.0
-  - git+https://git@github.com/ambv/black.git
+  - git+https://git@github.com/python/black.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ authors = [
     "Mika Naylor <mail@autophagy.io>",
     "Zsolt Dollenstein <zsol.zsol@gmail.com>",
 ]
-homepage = "https://github.com/ambv/black/"
+homepage = "https://github.com/python/black/"
 documentation = "https://black.readthedocs.io/en/stable/"
 license = "MIT"
 keywords = ["automation", "formatter", "yapf", "autopep8", "gofmt"]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords="automation formatter yapf autopep8 pyfmt gofmt rustfmt",
     author="Łukasz Langa",
     author_email="lukasz@langa.pl",
-    url="https://github.com/ambv/black",
+    url="https://github.com/python/black",
     license="MIT",
     py_modules=["black", "blackd"],
     packages=["blib2to3", "blib2to3.pgen2"],


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project created with the community in mind from Day 1. Today we moved it under the PSF umbrella. It's now available on GitHub under https://github.com/python/black/ . You install and use it just like before.

https://twitter.com/llanga/status/1123980466292445190

TODO

* [ ] Enable AppVeyor at https://ci.appveyor.com/project/python/black
* [ ] Enable Coveralls at https://coveralls.io/github/python/black
