### PR TITLE
Fix Flake8: B011 Do not call assert False

### DIFF
--- a/black.py
+++ b/black.py
@@ -3146,7 +3146,7 @@ def get_future_imports(node: Node) -> Set[str]:
             elif child.type == syms.import_as_names:
                 yield from get_imports_from_children(child.children)
             else:
-                assert False, "Invalid syntax parsing imports"
+                raise AssertionError("Invalid syntax parsing imports")
 
     for child in node.children:
         if child.type != syms.simple_stmt:


### PR DESCRIPTION
Fixes the Flake8 failure on the CI:

`black.py:3149:17: B011 Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().`

https://travis-ci.com/python/black/builds/110413516
