### PR TITLE
Avoid unstable formatting when comment follows escaped newline.

### DIFF
--- a/black.py
+++ b/black.py
@@ -2127,15 +2127,21 @@ def list_comments(prefix: str, *, is_endmarker: bool) -> List[ProtoComment]:
 
     consumed = 0
     nlines = 0
+    ignored_lines = 0
     for index, line in enumerate(prefix.split("\n")):
         consumed += len(line) + 1  # adding the length of the split '\n'
         line = line.lstrip()
         if not line:
             nlines += 1
         if not line.startswith("#"):
+            # Escaped newlines outside of a comment are not really newlines at
+            # all. We treat a single-line comment following an escaped newline
+            # as a simple trailing comment.
+            if line.endswith("\\"):
+                ignored_lines += 1
             continue
 
-        if index == 0 and not is_endmarker:
+        if index == ignored_lines and not is_endmarker:
             comment_type = token.COMMENT  # simple trailing comment
         else:
             comment_type = STANDALONE_COMMENT

--- a/tests/data/comment_after_escaped_newline.py
+++ b/tests/data/comment_after_escaped_newline.py
@@ -1,0 +1,8 @@
+def bob(): \
+         # pylint: disable=W9016
+    pass
+
+# output
+
+def bob():  # pylint: disable=W9016
+    pass

--- a/tests/data/comments.py
+++ b/tests/data/comments.py
@@ -75,6 +75,8 @@ class Foo:
 
 @fast(really=True)
 async def wat():
+    # This comment, for some reason \
+    # contains a trailing backslash.
     async with X.open_async() as x:  # Some more comments
         result = await x.method1()
     # Comment after ending a block.

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -397,6 +397,14 @@ class BlackTestCase(unittest.TestCase):
         black.assert_stable(source, actual, black.FileMode())
 
     @patch("black.dump_to_file", dump_to_stderr)
+    def test_comment_after_escaped_newline(self) -> None:
+        source, expected = read_data("comment_after_escaped_newline")
+        actual = fs(source)
+        self.assertFormatEqual(expected, actual)
+        black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, black.FileMode())
+
+    @patch("black.dump_to_file", dump_to_stderr)
     def test_cantfit(self) -> None:
         source, expected = read_data("cantfit")
         actual = fs(source)


### PR DESCRIPTION
Fixes #767.