### PR TITLE
Make --safe work for Python2.7 syntax, by using typed_ast

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ appdirs = "*"
 toml = ">=0.9.4"
 black = {path = ".",extras = ["d"],editable = true}
 aiohttp-cors = "*"
+typed-ast = ">=1.3.1"
 
 [dev-packages]
 pre-commit = "*"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,13 @@ setup(
     package_data={"blib2to3": ["*.txt"]},
     python_requires=">=3.6",
     zip_safe=False,
-    install_requires=["click>=6.5", "attrs>=18.1.0", "appdirs", "toml>=0.9.4"],
+    install_requires=[
+        "click>=6.5",
+        "attrs>=18.1.0",
+        "appdirs",
+        "toml>=0.9.4",
+        "typed-ast>=1.3.1",
+    ],
     extras_require={"d": ["aiohttp>=3.3.2", "aiohttp-cors"]},
     test_suite="tests.test_black",
     classifiers=[

--- a/tests/data/comments6.py
+++ b/tests/data/comments6.py
@@ -55,8 +55,8 @@ def f(
     an_element_with_a_long_value = calls() or more_calls() and more()  # type: bool
 
     tup = (
-        another_element,  # type: int
-        another_really_really_long_element_with_a_unnecessarily_long_name_to_describe_what_it_does_enterprise_style,  # type: int
+        another_element,
+        another_really_really_long_element_with_a_unnecessarily_long_name_to_describe_what_it_does_enterprise_style,
     )  # type: Tuple[int, int]
 
     a = (


### PR DESCRIPTION
Replace ast with typed_ast
Update all python2 tests to use safe checks. 
Remove fast vs safe test for blackd, because it was a non-test with typed_ast