### PR TITLE
Remove happiness of error message

### DIFF
--- a/black.py
+++ b/black.py
@@ -457,8 +457,7 @@ def main(
         )
 
     if verbose or not quiet:
-        bang = "💥 💔 💥" if report.return_code else "✨ 🍰 ✨"
-        out(f"All done! {bang}")
+        out("Oh no! 💥 💔 💥" if report.return_code else "All done! ✨ 🍰 ✨")
         click.secho(str(report), err=True)
     ctx.exit(report.return_code)
 


### PR DESCRIPTION
In the even that `black` encounters an error, the output gleefully tells the user it is "All done!", followed by the emoji ligature of sadness. 

This PR corrects that by ensuring that there are no mixed feelings on error, that indeed two collision emoji and a broken heart emoji is a very not good state to be in, and now returns "Oh no!"

Sample output: 

Before: 

```
error: cannot format app.py: Cannot parse: 13:33: @app.route("/", methods=["GET"]):
All done! 💥 💔 💥
1 file failed to reformat.
```

After: 

```
error: cannot format app.py: Cannot parse: 13:33: @app.route("/", methods=["GET"]):
Oh no! 💥 💔 💥
1 file failed to reformat.
```