### PR TITLE
Add Datadog to list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,7 +942,8 @@ write the above files to `.cache/black/<version>/`.
 
 The following notable open-source projects trust *Black* with enforcing
 a consistent code style: pytest, tox, Pyramid, Django Channels, Hypothesis,
-attrs, SQLAlchemy, Poetry, PyPA applications (Warehouse, Pipenv, virtualenv).
+attrs, SQLAlchemy, Poetry, PyPA applications (Warehouse, Pipenv, virtualenv),
+every Datadog Agent Integration.
 
 Are we missing anyone?  Let us know.
 


### PR DESCRIPTION
We recently began enforcing a consistent style for every existing and new Agent/Python integration. Here is the PR: https://github.com/DataDog/integrations-core/pull/3299

Here are the PRs that ported all 120+ Python integrations to the new style:

https://github.com/DataDog/integrations-core/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+Adhere+to+code+style
https://github.com/DataDog/integrations-extras/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+Adhere+to+code+style

Thank you very much for `black`, we find it invaluable!