### PR TITLE
Add W503 to default flake8 ignore list

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ you are probably already using.  You'd do it like this:
 max-line-length = 80
 ...
 select = C,E,F,W,B,B950
-ignore = E501
+ignore = E501,W503
 ```
 
 You'll find *Black*'s own .flake8 config file is configured like this.


### PR DESCRIPTION
W503 and W504 are mutually exclusive, to do with splitting binary operators across lines. Black reformats code according to W504, putting the operator on the start of the newline, therefore W503 needs to be ignored in the suggested Flake8 config to use with Black.