### PR TITLE
Force parentheses between unary op and binary power.

### DIFF
--- a/black.py
+++ b/black.py
@@ -1644,6 +1644,19 @@ class LineGenerator(Visitor[Line]):
             node.children[2].value = ""
         yield from super().visit_default(node)
 
+    def visit_factor(self, node: Node) -> Iterator[Line]:
+        """Force parentheses between a unary op and a binary power:
+
+        -2 ** 8 -> -(2 ** 8)
+        """
+        child = node.children[1]
+        if child.type == syms.power and len(child.children) == 3:
+            lpar = Leaf(token.LPAR, "(")
+            rpar = Leaf(token.RPAR, ")")
+            index = child.remove()
+            node.insert_child(index, Node(syms.atom, [lpar, child, rpar]))
+        yield from self.visit_default(node)
+
     def visit_INDENT(self, node: Node) -> Iterator[Line]:
         """Increase indentation level, maybe yield a line."""
         # In blib2to3 INDENT never holds comments.

--- a/black.py
+++ b/black.py
@@ -1653,7 +1653,7 @@ class LineGenerator(Visitor[Line]):
         if child.type == syms.power and len(child.children) == 3:
             lpar = Leaf(token.LPAR, "(")
             rpar = Leaf(token.RPAR, ")")
-            index = child.remove()
+            index = child.remove() or 0
             node.insert_child(index, Node(syms.atom, [lpar, child, rpar]))
         yield from self.visit_default(node)
 

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -11,13 +11,15 @@
  True
  False
  1
-@@ -29,62 +29,83 @@
+@@ -29,63 +29,84 @@
  ~great
  +value
  -1
  ~int and not v1 ^ 123 + v2 | True
  (~int) and (not ((v1 ^ (123 + v2)) | True))
+-+really ** -confusing ** ~operator ** -precedence
 -flags & ~ select.EPOLLIN and waiters.write_task is not None
+++(really ** -(confusing ** ~(operator ** -precedence)))
 +flags & ~select.EPOLLIN and waiters.write_task is not None
  lambda arg: None
  lambda a=True: a
@@ -116,7 +118,7 @@
  call(**self.screen_kwargs)
  call(b, **self.screen_kwargs)
  lukasz.langa.pl
-@@ -93,23 +114,25 @@
+@@ -94,23 +115,25 @@
  1.0 .real
  ....__class__
  list[str]
@@ -147,7 +149,7 @@
  slice[0:1:2]
  slice[:]
  slice[:-1]
-@@ -133,113 +156,171 @@
+@@ -134,113 +157,171 @@
  numpy[-(c + 1) :, d]
  numpy[:, l[-2]]
  numpy[:, ::-1]

--- a/tests/data/expression.py
+++ b/tests/data/expression.py
@@ -31,6 +31,7 @@ not great
 -1
 ~int and not v1 ^ 123 + v2 | True
 (~int) and (not ((v1 ^ (123 + v2)) | True))
++really ** -confusing ** ~operator ** -precedence
 flags & ~ select.EPOLLIN and waiters.write_task is not None
 lambda arg: None
 lambda a=True: a
@@ -280,6 +281,7 @@ not great
 -1
 ~int and not v1 ^ 123 + v2 | True
 (~int) and (not ((v1 ^ (123 + v2)) | True))
++(really ** -(confusing ** ~(operator ** -precedence)))
 flags & ~select.EPOLLIN and waiters.write_task is not None
 lambda arg: None
 lambda a=True: a


### PR DESCRIPTION
Fixes #646. This patch forces expressions containing unary and power ops, like this...

```py
+a ** -b ** ~c ** -d  # This is legal blackened code.
```

...to be reformatted with parentheses to make operator precedence clear, like this...

```py
+(a ** -(b ** ~(c ** -d)))  # This is legal blackened code.
```