### PR TITLE
Use nullcontext in case when lock is None. Shutdown pool after code formatting.

### DIFF
--- a/black.py
+++ b/black.py
@@ -3593,7 +3593,7 @@ def dump_to_file(*output: str) -> str:
 
 
 @contextmanager
-def nullcontext():
+def nullcontext() -> Iterator[None]:
     """Return context manager that does nothing.
     Similar to `nullcontext` from python 3.7"""
     yield


### PR DESCRIPTION
After code formatting ProcessPoolExecutor didn't shutdown, fix it.

Also use `nullcontext` from python3.7 to make code more readable.

For instance this code:
```python
if lock:
    lock.acquire()
try
    ...
finally:
    if lock:
        lock.release()
```
Turns into:
```python
with lock or nullcontext():
    ...
```